### PR TITLE
feat: bootstrap monorepo structure

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+pnpm-lock.yaml
+dist
+.DS_Store
+.vscode
+coverage
+*.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing to Kflow
+
+- PRs must include tests for parser or exporters.
+- Keep examples non-secret and runnable.
+- Use Conventional Commits for all changes.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2024 Wasantha K Weerakoone
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# Kflow
-Kflow is a open source workflow designer with natural language and AI empowered
+# Kflow — Open Source Workflow Language
+
+Human-first, AI-assisted workflow language. Author in **StoryFlow** (plain speak) → compile to **SimpleScript** (friendly YAML) → internal **IR** → export to BPMN/ASL/etc. Includes Codex/Copilot prompt recipes.
+
+## Packages
+
+- `packages/language`: parsers, schemas, lints, exporters, simulator.
+- `packages/studio`: web editor + AI assist + simulator UI.
+- `packages/vscode-ext`: VS Code extension for syntax highlighting, validation, and quick-fixes.
+
+## Getting Started
+
+```bash
+pnpm install
+pnpm -w -r build
+pnpm --filter studio dev
+```
+
+## License
+
+Apache-2.0

--- a/examples/approve-vacation.story
+++ b/examples/approve-vacation.story
@@ -1,0 +1,9 @@
+Flow: Approve Vacation
+Ask manager to approve the {dates} for {employee}
+If approved
+  Do: update HR system with {dates}
+  Send email to {employee}: "Approved"
+  Stop
+Otherwise
+  Send email to {employee}: "Not approved"
+  Stop

--- a/examples/approve-vacation.yaml
+++ b/examples/approve-vacation.yaml
@@ -1,0 +1,13 @@
+flow: Approve Vacation
+steps:
+  - ask: manager to approve {dates} for {employee}
+    id: askApproval
+    if:
+      cond: ${approved}
+      then:
+        - do: update HR system with {dates}
+        - send: email to {employee} "Approved"
+        - stop: success
+      else:
+        - send: email to {employee} "Not approved"
+        - stop: success

--- a/examples/fulfill-order.story
+++ b/examples/fulfill-order.story
@@ -1,0 +1,10 @@
+Flow: Fulfill Order
+Receive order request
+Do: check inventory
+If items available
+  Do: reserve inventory
+  Send confirmation email to {customer}
+  Remember: order_status = reserved
+Otherwise
+  Send email to {customer}: "Out of stock"
+  Stop

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "kflow",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Human-first, AI-assisted workflow language",
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "lint": "pnpm -r run lint",
+    "test": "pnpm -r run test"
+  }
+}

--- a/packages/language/package.json
+++ b/packages/language/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@kflow/language",
+  "version": "0.0.1",
+  "description": "Parsers, schemas, and exporters for Kflow",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "ajv": "^8.0.0",
+    "yaml": "^2.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "vitest": "^1.5.0",
+    "eslint": "^9.0.0"
+  }
+}

--- a/packages/language/src/compile/asl.ts
+++ b/packages/language/src/compile/asl.ts
@@ -1,0 +1,5 @@
+import { IR } from '../ir/types';
+export function irToASL(ir: IR): any {
+  // map to AWS Step Functions subset
+  return {};
+}

--- a/packages/language/src/compile/bpmn.ts
+++ b/packages/language/src/compile/bpmn.ts
@@ -1,0 +1,6 @@
+import { IR } from '../ir/types';
+export function irToBpmnXml(ir: IR): string {
+  // TODO: use bpmn-moddle to construct definitions/process/DI safely
+  // Return a minimal, engine-neutral BPMN 2.0 XML
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<definitions ...>\n  <!-- build from IR -->\n</definitions>`;
+}

--- a/packages/language/src/compile/index.ts
+++ b/packages/language/src/compile/index.ts
@@ -1,0 +1,2 @@
+export * from './bpmn';
+export * from './asl';

--- a/packages/language/src/index.ts
+++ b/packages/language/src/index.ts
@@ -1,0 +1,5 @@
+export * from './simplescript';
+export * from './storyflow';
+export * from './ir/types';
+export * from './compile';
+export * from './simulate';

--- a/packages/language/src/ir/types.ts
+++ b/packages/language/src/ir/types.ts
@@ -1,0 +1,18 @@
+export type IR = {
+  name: string;
+  vars?: Record<string, unknown>;
+  states: IRState[];
+  start: string;
+};
+
+export type IRState =
+  | { id: string; kind: 'task'; action: string; retry?: Retry; timeout?: number; next?: string }
+  | { id: string; kind: 'userTask'; prompt: string; next?: string }
+  | { id: string; kind: 'send'; channel: string; to: string; message: string; next?: string }
+  | { id: string; kind: 'receive'; event: string; next?: string }
+  | { id: string; kind: 'choice'; branches: { cond: string; next: string }[]; otherwise?: string }
+  | { id: string; kind: 'parallel'; branches: string[]; join: string }
+  | { id: string; kind: 'wait'; until?: string; delayMs?: number; next?: string }
+  | { id: string; kind: 'stop'; reason?: string };
+
+export type Retry = { max: number; backoffMs?: number; jitter?: boolean };

--- a/packages/language/src/schemas/simplescript.schema.json
+++ b/packages/language/src/schemas/simplescript.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kflow.dev/schema/simplescript-1.0.json",
+  "title": "SimpleScript",
+  "type": "object",
+  "required": ["flow", "steps"],
+  "properties": {
+    "flow": { "type": "string" },
+    "trigger": { "type": ["string", "object"] },
+    "vars": { "type": "object", "additionalProperties": true },
+    "steps": { "$ref": "#/definitions/steps" }
+  },
+  "definitions": {
+    "steps": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/step" },
+      "minItems": 1
+    },
+    "step": {
+      "type": "object",
+      "oneOf": [
+        {"required": ["do"]},
+        {"required": ["ask"]},
+        {"required": ["send"]},
+        {"required": ["receive"]},
+        {"required": ["wait"]},
+        {"required": ["if"]},
+        {"required": ["meanwhile"]},
+        {"required": ["repeat"]},
+        {"required": ["remember"]},
+        {"required": ["stop"]}
+      ],
+      "properties": {
+        "id": {"type": "string"},
+        "do": {"type": ["string", "object"]},
+        "ask": {"type": ["string", "object"]},
+        "send": {"type": ["string", "object"]},
+        "receive": {"type": ["string", "object"]},
+        "wait": {"type": ["string", "object"]},
+        "if": {
+          "type": "object",
+          "properties": {
+            "cond": {"type": "string"},
+            "then": {"$ref": "#/definitions/steps"},
+            "else": {"$ref": "#/definitions/steps"}
+          },
+          "required": ["cond", "then"]
+        },
+        "meanwhile": {"$ref": "#/definitions/steps"},
+        "repeat": {
+          "type": "object",
+          "properties": {
+            "every": {"type": "string"},
+            "until": {"type": "string"},
+            "steps": {"$ref": "#/definitions/steps"}
+          },
+          "required": ["steps"]
+        },
+        "remember": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "stop": {"type": ["boolean", "string", "object"]},
+        "retry": {"type": ["boolean", "object"]},
+        "timeout": {"type": ["string", "number"]}
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/packages/language/src/simplescript/index.ts
+++ b/packages/language/src/simplescript/index.ts
@@ -1,0 +1,1 @@
+export * from './parse';

--- a/packages/language/src/simplescript/parse.ts
+++ b/packages/language/src/simplescript/parse.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import yaml from 'yaml';
+import Ajv from 'ajv';
+import schema from '../schemas/simplescript.schema.json';
+
+export type SimpleScript = any; // replace with generated types
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+const validate = ajv.compile(schema as any);
+
+export function parseSimpleScript(input: string): { doc: SimpleScript; errors: string[] } {
+  const doc = yaml.parse(input);
+  const ok = validate(doc);
+  return { doc, errors: ok ? [] : (validate.errors || []).map(e => ajv.errorsText([e])) };
+}
+
+export function parseSimpleScriptFile(path: string) {
+  const input = readFileSync(path, 'utf-8');
+  return parseSimpleScript(input);
+}

--- a/packages/language/src/simulate/index.ts
+++ b/packages/language/src/simulate/index.ts
@@ -1,0 +1,6 @@
+import { IR } from '../ir/types';
+
+export function simulate(ir: IR) {
+  // TODO: implement in-memory runner
+  return { start: ir.start, states: ir.states.length };
+}

--- a/packages/language/src/storyflow/compile.ts
+++ b/packages/language/src/storyflow/compile.ts
@@ -1,0 +1,17 @@
+// naive prototype: convert StoryFlow lines to SimpleScript YAML
+export function storyToSimple(story: string): string {
+  const lines = story.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+  const title = lines.find(l => l.toLowerCase().startsWith('flow:'))?.replace(/^[^:]+:/, '').trim() || 'Untitled';
+  const steps = lines
+    .filter(l => !/^flow:|^trigger:/i.test(l))
+    .map(l => {
+      if (/^ask /i.test(l)) return { ask: l.slice(4).trim() };
+      if (/^do:/i.test(l) || /^do /i.test(l)) return { do: l.replace(/^do:?\s*/i,'') };
+      if (/^send /i.test(l)) return { send: l.slice(5).trim() };
+      if (/^receive /i.test(l)) return { receive: l.slice(8).trim() };
+      if (/^wait /i.test(l)) return { wait: l.slice(5).trim() };
+      if (/^stop/i.test(l)) return { stop: true };
+      return { remember: { note: l } };
+    });
+  return JSON.stringify({ flow: title, steps }, null, 2);
+}

--- a/packages/language/src/storyflow/index.ts
+++ b/packages/language/src/storyflow/index.ts
@@ -1,0 +1,1 @@
+export * from './compile';

--- a/packages/language/test/simplescript.test.ts
+++ b/packages/language/test/simplescript.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { parseSimpleScript } from '../src/simplescript/parse';
+
+describe('parseSimpleScript', () => {
+  it('parses valid YAML and returns no errors', () => {
+    const { doc, errors } = parseSimpleScript(`flow: Demo\nsteps:\n  - do: test`);
+    expect(errors).toEqual([]);
+    expect(doc.flow).toBe('Demo');
+  });
+
+  it('reports schema violations', () => {
+    const { errors } = parseSimpleScript(`flow: Demo`);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/language/test/storyflow.test.ts
+++ b/packages/language/test/storyflow.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { storyToSimple } from '../src/storyflow/compile';
+
+describe('storyToSimple', () => {
+  it('converts plain text to SimpleScript JSON string', () => {
+    const result = storyToSimple('Flow: Demo\nAsk user for input\nStop');
+    const parsed = JSON.parse(result);
+    expect(parsed.flow).toBe('Demo');
+    expect(parsed.steps).toHaveLength(2);
+  });
+});

--- a/packages/language/tsconfig.json
+++ b/packages/language/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/studio/index.html
+++ b/packages/studio/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kflow Studio</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@kflow/studio",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Web editor for Kflow",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.5.0",
+    "vite": "^5.0.0",
+    "vitest": "^1.5.0",
+    "eslint": "^9.0.0"
+  }
+}

--- a/packages/studio/src/app/index.ts
+++ b/packages/studio/src/app/index.ts
@@ -1,0 +1,1 @@
+export * from './main';

--- a/packages/studio/src/app/main.tsx
+++ b/packages/studio/src/app/main.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import { rewriteToSimpleScript, guardrails } from '../codex';
+
+export function App() {
+  const [story, setStory] = useState('Flow: Example');
+  const [assistVisible, setAssistVisible] = useState(false);
+
+  return (
+    <div>
+      <h1>Kflow Studio</h1>
+      <textarea value={story} onChange={event => setStory(event.target.value)} />
+      <button type="button" onClick={() => setAssistVisible(visible => !visible)}>
+        {assistVisible ? 'Hide Assist' : 'Assist'}
+      </button>
+      {assistVisible && <pre>{rewriteToSimpleScript}</pre>}
+      <ul>
+        {guardrails.map(rule => (
+          <li key={rule}>{rule}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/studio/src/codex/index.ts
+++ b/packages/studio/src/codex/index.ts
@@ -1,0 +1,1 @@
+export * from './prompts';

--- a/packages/studio/src/codex/prompts.ts
+++ b/packages/studio/src/codex/prompts.ts
@@ -1,0 +1,19 @@
+export const rewriteToSimpleScript = `SYSTEM: You convert plain StoryFlow lines into SimpleScript YAML, preserving intent, adding ids, and ensuring steps are explicit. Do not invent APIs; leave actions as text.
+USER:
+Flow: {title}
+{story_text}`;
+
+export const clarifyAmbiguities = `SYSTEM: Identify ambiguities (who, when, what data) and propose 3 concrete options each.
+USER: {simplescript_yaml}`;
+
+export const generateTestScenarios = `SYSTEM: Produce table of test cases (happy path, failures, timeouts). Include inputs, expected path, and outputs.
+USER: {simplescript_yaml}`;
+
+export const suggestConnectors = `SYSTEM: Suggest connector candidates (email/http/webhook/db/queue) for each 'do'/'send'/'receive' step; list minimal required fields.
+USER: {simplescript_yaml}`;
+
+export const guardrails = [
+  'Never call external APIs.',
+  'Don’t add secrets; use placeholders.',
+  'Keep vocabulary to the 12 verbs unless compiling.'
+];

--- a/packages/studio/src/main.tsx
+++ b/packages/studio/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { App } from './app/main';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/packages/studio/src/vite-env.d.ts
+++ b/packages/studio/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/studio/tsconfig.json
+++ b/packages/studio/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});

--- a/packages/vscode-ext/language-configuration.json
+++ b/packages/vscode-ext/language-configuration.json
@@ -1,0 +1,16 @@
+{
+  "comments": {
+    "lineComment": "#"
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"" }
+  ]
+}

--- a/packages/vscode-ext/package.json
+++ b/packages/vscode-ext/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "kflow-vscode",
+  "displayName": "Kflow",
+  "version": "0.0.1",
+  "publisher": "kflow",
+  "engines": {
+    "vscode": "^1.80.0"
+  },
+  "categories": ["Other"],
+  "main": "dist/extension.js",
+  "contributes": {
+    "languages": [
+      {
+        "id": "storyflow",
+        "aliases": ["StoryFlow"],
+        "extensions": [".story"],
+        "configuration": "./language-configuration.json"
+      }
+    ]
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint 'src/**/*.ts'",
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "vitest": "^1.5.0",
+    "eslint": "^9.0.0"
+  }
+}

--- a/packages/vscode-ext/src/extension.ts
+++ b/packages/vscode-ext/src/extension.ts
@@ -1,0 +1,22 @@
+import { ExtensionContext, languages } from 'vscode';
+
+export function activate(context: ExtensionContext) {
+  const collection = languages.createDiagnosticCollection('storyflow');
+  context.subscriptions.push(collection);
+
+  context.subscriptions.push(
+    languages.registerDocumentSemanticTokensProvider(
+      { language: 'storyflow' },
+      {
+        provideDocumentSemanticTokens() {
+          return undefined;
+        }
+      },
+      { tokenTypes: [], tokenModifiers: [] }
+    )
+  );
+
+  collection.set([], []);
+}
+
+export function deactivate() {}

--- a/packages/vscode-ext/tsconfig.json
+++ b/packages/vscode-ext/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"},
+  "include": ["src/**/*"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold language, studio, and VS Code extension packages with initial TypeScript sources
- add canonical SimpleScript schema, parsing utilities, StoryFlow compiler stub, and IR definitions
- seed examples, workspace configuration, and contributor guidance for the new monorepo

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d735e5930483238644475d90ee4496