### PR TITLE
Implement BPMN export and simulation enhancements

### DIFF
--- a/docs/readme-enhancement-plan.md
+++ b/docs/readme-enhancement-plan.md
@@ -1,0 +1,18 @@
+# README Alignment Plan
+
+The main README describes BPMN 2.0 exports, AI-ready tooling, and an in-memory simulation story. To make the codebase better match those claims we will:
+
+1. **Implement BPMN XML export**
+   - Replace the current stubbed `irToBpmnXml` implementation with logic that converts the intermediate representation into a BPMN 2.0 compliant XML document.
+   - Cover all currently modelled IR state kinds (tasks, user tasks, messaging, waits, branching, and termination) and ensure outgoing sequence flows line up with the README promise of “BPMN-compliant workflow diagrams.”
+   - Provide unit tests that assert the resulting XML contains expected structural elements so future changes do not regress the export.
+
+2. **Provide an in-memory simulator**
+   - Expand the `simulate` helper so that it can execute an IR graph using deterministic rules, matching the README’s mention of real-time validation and simulation capabilities.
+   - Support user, service, messaging, wait, branching, and stop states while surfacing runtime information such as visited states and produced messages.
+   - Add tests that exercise the simulator over a representative IR with branching paths.
+
+3. **Quality gates**
+   - Introduce Vitest-based unit coverage for both enhancements and wire them into the workspace `test` command so the README’s “Quality Assurance” section remains accurate.
+
+Executing this plan will make the language package demonstrably capable of generating BPMN output and simulating flows as described in the README.

--- a/packages/language/src/__tests__/bpmn.test.ts
+++ b/packages/language/src/__tests__/bpmn.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { irToBpmnXml } from '../compile/bpmn';
+import type { IR } from '../ir/types';
+
+const sampleIr: IR = {
+  name: 'Order Processing',
+  start: 'startTask',
+  states: [
+    { id: 'startTask', kind: 'task', action: 'Initialize order context', next: 'approval' },
+    {
+      id: 'approval',
+      kind: 'userTask',
+      prompt: 'Manager approves the order',
+      next: 'decision',
+    },
+    {
+      id: 'decision',
+      kind: 'choice',
+      branches: [
+        { cond: 'approved', next: 'sendConfirmation' },
+      ],
+      otherwise: 'rejectOrder',
+    },
+    {
+      id: 'sendConfirmation',
+      kind: 'send',
+      channel: 'email',
+      to: 'customer',
+      message: 'Order approved',
+      next: 'waitShipping',
+    },
+    {
+      id: 'waitShipping',
+      kind: 'wait',
+      delayMs: 3600000,
+      next: 'ship',
+    },
+    {
+      id: 'ship',
+      kind: 'task',
+      action: 'Ship goods to customer',
+      next: 'stopState',
+    },
+    {
+      id: 'rejectOrder',
+      kind: 'send',
+      channel: 'email',
+      to: 'customer',
+      message: 'Order rejected',
+      next: 'stopState',
+    },
+    { id: 'stopState', kind: 'stop', reason: 'Process finished' },
+  ],
+};
+
+describe('irToBpmnXml', () => {
+  it('produces BPMN XML with expected flow nodes and sequence flows', () => {
+    const xml = irToBpmnXml(sampleIr);
+
+    expect(xml).toContain('<bpmn:startEvent');
+    expect(xml).toContain('Process_Order_Processing');
+    expect(xml).toContain('UserTask_approval');
+    expect(xml).toContain('<bpmn:sequenceFlow');
+    expect(xml).toContain('bpmn:conditionExpression');
+    expect(xml).toContain('IntermediateCatchEvent_waitShipping');
+    expect(xml.trim().startsWith('<?xml')).toBe(true);
+  });
+
+  it('throws when IR has no states', () => {
+    expect(() => irToBpmnXml({ name: 'Empty', start: 'none', states: [] })).toThrow();
+  });
+});

--- a/packages/language/src/__tests__/simulate.test.ts
+++ b/packages/language/src/__tests__/simulate.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import type { IR } from '../ir/types';
+import { simulate } from '../simulate';
+
+const ir: IR = {
+  name: 'Support Flow',
+  start: 'intake',
+  states: [
+    { id: 'intake', kind: 'task', action: 'Capture ticket', next: 'triage' },
+    {
+      id: 'triage',
+      kind: 'choice',
+      branches: [
+        { cond: 'urgent', next: 'notifyOnCall' },
+        { cond: 'standard', next: 'assignAgent' },
+      ],
+      otherwise: 'close',
+    },
+    {
+      id: 'notifyOnCall',
+      kind: 'send',
+      channel: 'sms',
+      to: 'on_call_engineer',
+      message: 'New urgent ticket',
+      next: 'assignAgent',
+    },
+    {
+      id: 'assignAgent',
+      kind: 'userTask',
+      prompt: 'Assign support agent',
+      next: 'awaitCustomer',
+    },
+    { id: 'awaitCustomer', kind: 'receive', event: 'customer_response', next: 'close' },
+    { id: 'close', kind: 'stop', reason: 'Ticket closed' },
+  ],
+};
+
+describe('simulate', () => {
+  it('walks through the flow using provided branch hints', () => {
+    const result = simulate(ir, {
+      choices: { triage: 'urgent' },
+      events: ['customer_response'],
+    });
+
+    expect(result.status).toBe('stopped');
+    expect(result.visited).toEqual(['intake', 'triage', 'notifyOnCall', 'assignAgent', 'awaitCustomer', 'close']);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]).toMatchObject({ channel: 'sms', to: 'on_call_engineer' });
+  });
+
+  it('pauses when waiting for events or timers', () => {
+    const waiting = simulate(ir, { choices: { triage: 'standard' } });
+    expect(waiting.status).toBe('waiting');
+    expect(waiting.waitingFor).toMatchObject({ type: 'receive', stateId: 'awaitCustomer' });
+  });
+});

--- a/packages/language/src/compile/bpmn.ts
+++ b/packages/language/src/compile/bpmn.ts
@@ -1,6 +1,285 @@
-import { IR } from '../ir/types';
+import { IR, IRState } from '../ir/types';
+
+type BpmnElement = {
+  id: string;
+  tag: string;
+  name?: string;
+  attributes?: Record<string, string>;
+  incoming: string[];
+  outgoing: string[];
+  body?: string[];
+};
+
+type SequenceFlow = {
+  id: string;
+  sourceRef: string;
+  targetRef: string;
+  conditionExpression?: string;
+  isDefault?: boolean;
+};
+
+const BPMN_NS = {
+  definitions:
+    'bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"',
+};
+
 export function irToBpmnXml(ir: IR): string {
-  // TODO: use bpmn-moddle to construct definitions/process/DI safely
-  // Return a minimal, engine-neutral BPMN 2.0 XML
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<definitions ...>\n  <!-- build from IR -->\n</definitions>`;
+  const stateMap = new Map(ir.states.map(state => [state.id, state] as const));
+  if (!stateMap.size) {
+    throw new Error('Cannot render BPMN without IR states');
+  }
+
+  const sanitize = (value: string) => value.replace(/[^a-zA-Z0-9_]+/g, '_');
+  const escapeXml = (value: string) =>
+    value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;');
+
+  const elementByState = new Map<string, BpmnElement>();
+  const elements: BpmnElement[] = [];
+  const flows: SequenceFlow[] = [];
+  let flowCounter = 0;
+
+  const registerElement = (state: IRState): BpmnElement => {
+    const existing = elementByState.get(state.id);
+    if (existing) return existing;
+    const element = createElementForState(state);
+    elementByState.set(state.id, element);
+    elements.push(element);
+    return element;
+  };
+
+  const createElementForState = (state: IRState): BpmnElement => {
+    const base = sanitize(state.id || 'state');
+    const baseElement: BpmnElement = {
+      id: '',
+      tag: '',
+      incoming: [],
+      outgoing: [],
+    };
+
+    switch (state.kind) {
+      case 'task':
+        return {
+          ...baseElement,
+          id: `ServiceTask_${base}`,
+          tag: 'bpmn:serviceTask',
+          name: state.action,
+          body: state.retry
+            ? [
+                `<bpmn:documentation>${escapeXml(
+                  `Retry up to ${state.retry.max} times${state.retry.backoffMs ? `; backoff ${state.retry.backoffMs}ms` : ''}`,
+                )}</bpmn:documentation>`,
+              ]
+            : undefined,
+        };
+      case 'userTask':
+        return {
+          ...baseElement,
+          id: `UserTask_${base}`,
+          tag: 'bpmn:userTask',
+          name: state.prompt,
+        };
+      case 'send':
+        return {
+          ...baseElement,
+          id: `SendTask_${base}`,
+          tag: 'bpmn:sendTask',
+          name: `Send via ${state.channel}`,
+          body: [
+            `<bpmn:documentation>${escapeXml(
+              `To ${state.to}: ${state.message}`,
+            )}</bpmn:documentation>`,
+          ],
+        };
+      case 'receive':
+        return {
+          ...baseElement,
+          id: `ReceiveTask_${base}`,
+          tag: 'bpmn:receiveTask',
+          name: `Wait for ${state.event}`,
+        };
+      case 'choice':
+        return {
+          ...baseElement,
+          id: `ExclusiveGateway_${base}`,
+          tag: 'bpmn:exclusiveGateway',
+        };
+      case 'parallel':
+        return {
+          ...baseElement,
+          id: `ParallelGateway_${base}`,
+          tag: 'bpmn:parallelGateway',
+        };
+      case 'wait':
+        return {
+          ...baseElement,
+          id: `IntermediateCatchEvent_${base}`,
+          tag: 'bpmn:intermediateCatchEvent',
+          name: state.until ? `Wait until ${state.until}` : state.delayMs ? `Wait ${formatDuration(state.delayMs)}` : 'Wait',
+          body: [
+            '<bpmn:timerEventDefinition>' +
+              (state.until
+                ? `<bpmn:timeDate>${escapeXml(state.until)}</bpmn:timeDate>`
+                : state.delayMs
+                ? `<bpmn:timeDuration>${formatDuration(state.delayMs)}</bpmn:timeDuration>`
+                : '') +
+              '</bpmn:timerEventDefinition>',
+          ],
+        };
+      case 'stop':
+        return {
+          ...baseElement,
+          id: `EndEvent_${base}`,
+          tag: 'bpmn:endEvent',
+          name: state.reason ?? 'End',
+        };
+      default:
+        // Exhaustive guard to satisfy TypeScript
+        throw new Error(`Unsupported IR state kind: ${(state as IRState).kind}`);
+    }
+  };
+
+  const ensureStateElement = (stateId: string): BpmnElement => {
+    const state = stateMap.get(stateId);
+    if (!state) throw new Error(`Unknown IR state referenced: ${stateId}`);
+    return registerElement(state);
+  };
+
+  const addSequenceFlow = (
+    source: BpmnElement,
+    targetStateId: string,
+    options?: { condition?: string; isDefault?: boolean },
+  ) => {
+    const target = ensureStateElement(targetStateId);
+    const flowId = `Flow_${++flowCounter}`;
+    const flow: SequenceFlow = {
+      id: flowId,
+      sourceRef: source.id,
+      targetRef: target.id,
+    };
+    if (options?.condition) {
+      flow.conditionExpression = options.condition;
+    }
+    if (options?.isDefault) {
+      flow.isDefault = true;
+    }
+    flows.push(flow);
+    source.outgoing.push(flowId);
+    target.incoming.push(flowId);
+  };
+
+  // Prepare BPMN nodes for every state referenced from the start
+  for (const state of ir.states) {
+    registerElement(state);
+  }
+
+  const startElement: BpmnElement = {
+    id: `StartEvent_${sanitize(ir.start)}`,
+    tag: 'bpmn:startEvent',
+    name: 'Start',
+    incoming: [],
+    outgoing: [],
+  };
+
+  const processElements: BpmnElement[] = [startElement, ...elements];
+
+  // Wire start event to the initial state
+  addSequenceFlow(startElement, ir.start);
+
+  for (const state of ir.states) {
+    const element = ensureStateElement(state.id);
+    switch (state.kind) {
+      case 'task':
+      case 'userTask':
+      case 'send':
+      case 'receive':
+      case 'wait':
+        if (state.next) {
+          addSequenceFlow(element, state.next);
+        }
+        break;
+      case 'choice':
+        state.branches.forEach(branch => {
+          addSequenceFlow(element, branch.next, { condition: branch.cond });
+        });
+        if (state.otherwise) {
+          addSequenceFlow(element, state.otherwise, { isDefault: true });
+        }
+        break;
+      case 'parallel':
+        state.branches.forEach(branchId => {
+          addSequenceFlow(element, branchId);
+        });
+        break;
+      case 'stop':
+        // Terminal node, no outgoing flow
+        break;
+      default:
+        throw new Error(`Unsupported IR state kind: ${(state as IRState).kind}`);
+    }
+  }
+
+  const flowXml = flows
+    .map(flow => {
+      const attrs = [
+        `id="${flow.id}"`,
+        `sourceRef="${flow.sourceRef}"`,
+        `targetRef="${flow.targetRef}"`,
+      ];
+      if (flow.isDefault) {
+        attrs.push('bpmn:isDefault="true"');
+      }
+      const conditionXml = flow.conditionExpression
+        ? `\n      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${escapeXml(
+            flow.conditionExpression,
+          )}</bpmn:conditionExpression>\n    `
+        : '';
+      return `    <bpmn:sequenceFlow ${attrs.join(' ')}>${conditionXml}</bpmn:sequenceFlow>`;
+    })
+    .join('\n');
+  const elementXml = processElements
+    .map(element => {
+      const attrs: string[] = [`id="${element.id}"`];
+      if (element.name) {
+        attrs.push(`name="${escapeXml(element.name)}"`);
+      }
+      if (element.attributes) {
+        for (const [key, value] of Object.entries(element.attributes)) {
+          attrs.push(`${key}="${escapeXml(value)}"`);
+        }
+      }
+      const incoming = element.incoming.map(flowId => `      <bpmn:incoming>${flowId}</bpmn:incoming>`).join('\n');
+      const outgoing = element.outgoing.map(flowId => `      <bpmn:outgoing>${flowId}</bpmn:outgoing>`).join('\n');
+      const body = element.body?.map(line => `      ${line}`).join('\n') ?? '';
+      const inner = [incoming, outgoing, body].filter(Boolean).join('\n');
+      if (inner) {
+        return `    <${element.tag} ${attrs.join(' ')}>\n${inner}\n    </${element.tag}>`;
+      }
+      return `    <${element.tag} ${attrs.join(' ')} />`;
+    })
+    .join('\n');
+
+  const xml = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    `<${BPMN_NS.definitions} id="Definitions_${sanitize(ir.name)}" targetNamespace="https://kflow.dev/bpmn">`,
+    `  <bpmn:process id="Process_${sanitize(ir.name)}" name="${escapeXml(ir.name)}" isExecutable="false">`,
+    elementXml,
+    flowXml,
+    '  </bpmn:process>',
+    '</bpmn:definitions>',
+  ].join('\n');
+
+  return xml;
+}
+
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return 'PT0S';
+  const totalSeconds = Math.round(ms / 1000);
+  const seconds = totalSeconds % 60;
+  const minutes = Math.floor(totalSeconds / 60) % 60;
+  const hours = Math.floor(totalSeconds / 3600);
+  const parts: string[] = ['PT'];
+  if (hours) parts.push(`${hours}H`);
+  if (minutes) parts.push(`${minutes}M`);
+  parts.push(`${seconds}S`);
+  return parts.join('');
 }

--- a/packages/language/src/simplescript/parse.ts
+++ b/packages/language/src/simplescript/parse.ts
@@ -1,11 +1,11 @@
 import { readFileSync } from 'node:fs';
 import yaml from 'yaml';
-import Ajv from 'ajv';
+import Ajv2020 from 'ajv/dist/2020';
 import schema from '../schemas/simplescript.schema.json';
 
 export type SimpleScript = any; // replace with generated types
 
-const ajv = new Ajv({ allErrors: true, strict: false });
+const ajv = new Ajv2020({ allErrors: true, strict: false });
 const validate = ajv.compile(schema as any);
 
 export function parseSimpleScript(input: string): { doc: SimpleScript; errors: string[] } {

--- a/packages/language/src/simulate/index.ts
+++ b/packages/language/src/simulate/index.ts
@@ -1,6 +1,163 @@
-import { IR } from '../ir/types';
+import { IR, IRState } from '../ir/types';
 
-export function simulate(ir: IR) {
-  // TODO: implement in-memory runner
-  return { start: ir.start, states: ir.states.length };
+export type SimulationOptions = {
+  choices?: Record<string, string>;
+  events?: string[];
+  autoAdvanceWaits?: boolean;
+  maxSteps?: number;
+};
+
+export type SimulationLogEntry =
+  | { type: 'task'; id: string; action: string }
+  | { type: 'userTask'; id: string; prompt: string }
+  | { type: 'message'; id: string; channel: string; to: string; message: string }
+  | { type: 'receive'; id: string; event: string }
+  | { type: 'wait'; id: string; until?: string; delayMs?: number }
+  | { type: 'choice'; id: string; selected: string }
+  | { type: 'parallel'; id: string; branches: string[]; join?: string }
+  | { type: 'stop'; id: string; reason?: string };
+
+export type SimulationResult = {
+  visited: string[];
+  log: SimulationLogEntry[];
+  messages: { id: string; channel: string; to: string; message: string }[];
+  status: 'completed' | 'waiting' | 'stopped';
+  waitingFor?: { type: 'receive' | 'wait'; stateId: string };
+};
+
+export function simulate(ir: IR, options: SimulationOptions = {}): SimulationResult {
+  if (!ir.states.length) {
+    return { visited: [], log: [], messages: [], status: 'completed' };
+  }
+
+  const stateMap = new Map(ir.states.map(state => [state.id, state] as const));
+  if (!stateMap.has(ir.start)) {
+    throw new Error(`Unknown start state "${ir.start}"`);
+  }
+
+  const events = new Set(options.events ?? []);
+  const agenda: string[] = [ir.start];
+  const visited: string[] = [];
+  const messages: SimulationResult['messages'] = [];
+  const log: SimulationLogEntry[] = [];
+  const scheduled = new Set(agenda);
+  const maxSteps = options.maxSteps ?? 1000;
+  let status: SimulationResult['status'] = 'completed';
+  let waitingFor: SimulationResult['waitingFor'];
+
+  for (let step = 0; step < maxSteps && agenda.length; step += 1) {
+    const stateId = agenda.shift()!;
+    scheduled.delete(stateId);
+    const state = stateMap.get(stateId);
+    if (!state) {
+      throw new Error(`Encountered missing state "${stateId}" during simulation`);
+    }
+
+    visited.push(stateId);
+
+    switch (state.kind) {
+      case 'task':
+        log.push({ type: 'task', id: state.id, action: state.action });
+        enqueueNext(state.next);
+        break;
+      case 'userTask':
+        log.push({ type: 'userTask', id: state.id, prompt: state.prompt });
+        enqueueNext(state.next);
+        break;
+      case 'send':
+        messages.push({ id: state.id, channel: state.channel, to: state.to, message: state.message });
+        log.push({ type: 'message', id: state.id, channel: state.channel, to: state.to, message: state.message });
+        enqueueNext(state.next);
+        break;
+      case 'receive':
+        if (events.has(state.event)) {
+          events.delete(state.event);
+          log.push({ type: 'receive', id: state.id, event: state.event });
+          enqueueNext(state.next);
+        } else {
+          status = 'waiting';
+          waitingFor = { type: 'receive', stateId: state.id };
+          log.push({ type: 'receive', id: state.id, event: state.event });
+          agenda.unshift(state.id);
+          scheduled.add(state.id);
+          breakLoop();
+        }
+        break;
+      case 'wait':
+        log.push({ type: 'wait', id: state.id, until: state.until, delayMs: state.delayMs });
+        if (options.autoAdvanceWaits) {
+          enqueueNext(state.next);
+        } else {
+          status = 'waiting';
+          waitingFor = { type: 'wait', stateId: state.id };
+          agenda.unshift(state.id);
+          scheduled.add(state.id);
+          breakLoop();
+        }
+        break;
+      case 'choice': {
+        const chosen = selectChoice(state, options.choices);
+        log.push({ type: 'choice', id: state.id, selected: chosen.next });
+        enqueueNext(chosen.next);
+        break;
+      }
+      case 'parallel':
+        log.push({ type: 'parallel', id: state.id, branches: [...state.branches], join: state.join });
+        for (const branch of state.branches) {
+          enqueueNext(branch);
+        }
+        enqueueNext(state.join);
+        break;
+      case 'stop':
+        log.push({ type: 'stop', id: state.id, reason: state.reason });
+        status = 'stopped';
+        agenda.length = 0;
+        break;
+      default:
+        exhaustive(state);
+    }
+
+    if (status !== 'completed') {
+      break;
+    }
+  }
+
+  if (agenda.length && status === 'completed') {
+    status = 'waiting';
+  }
+
+  return { visited, log, messages, status, waitingFor };
+
+  function enqueueNext(next?: string) {
+    if (!next) return;
+    if (!scheduled.has(next)) {
+      agenda.push(next);
+      scheduled.add(next);
+    }
+  }
+
+  function breakLoop() {
+    agenda.length = Math.min(agenda.length, 1);
+  }
+}
+
+function selectChoice(state: Extract<IRState, { kind: 'choice' }>, choices?: Record<string, string>) {
+  if (choices) {
+    const hinted = choices[state.id];
+    if (hinted) {
+      const matched = state.branches.find(branch => branch.next === hinted || branch.cond === hinted);
+      if (matched) return matched;
+      if (state.otherwise) {
+        return { cond: 'otherwise', next: state.otherwise };
+      }
+    }
+  }
+  const fallback = state.branches[0];
+  if (fallback) return fallback;
+  if (state.otherwise) return { cond: 'otherwise', next: state.otherwise };
+  throw new Error(`Choice state "${state.id}" has no branches`);
+}
+
+function exhaustive(_: never): never {
+  throw new Error('Unhandled IR state kind');
 }

--- a/packages/language/tsconfig.json
+++ b/packages/language/tsconfig.json
@@ -4,5 +4,6 @@
     "rootDir": "src",
     "outDir": "dist"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/__tests__/**/*", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- document a plan to align the codebase with the README commitments
- implement a BPMN XML exporter and in-memory IR simulator covering the documented behaviors
- add Vitest coverage plus schema validation fixes to keep existing tests passing

## Testing
- `pnpm --filter @kflow/language test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68d9f5a449ec8323b04e2b26be5a6768