### PR TITLE
Add Kflow language dictionary, user manual, and enhancement vision

### DIFF
--- a/docs/kflow-language-dictionary.md
+++ b/docs/kflow-language-dictionary.md
@@ -1,0 +1,80 @@
+# Kflow Language Dictionary
+
+This dictionary catalogs the domain vocabulary, syntax keywords, and semantic concepts that appear in Kflow stories. Use it as a quick reference while writing or reviewing workflows.
+
+## Core Structural Terms
+
+| Term | Definition | Example |
+| --- | --- | --- |
+| **Flow** | Declares the workflow name and establishes the context for all subsequent steps. | `Flow: Employee Onboarding`
+| **Step** | Any executable or descriptive line after the flow declaration. Steps are parsed in order and may introduce branching. | `Do: validate employee record`
+| **Branch** | A conditional path that is entered when its condition is satisfied. Branches are created with `If`/`Otherwise`. | See the conditional example below.
+| **Indentation** | Two-space indentation indicates the parent-child relationship between branch blocks. | `If condition` followed by two-space indented steps.
+| **Template Variable** | Placeholder surrounded by `{}`. Variables are extracted and categorized during compilation. | `{manager}` or `{payment_amount}`
+
+## Action Keywords
+
+| Keyword | Meaning in the compiler | Default BPMN mapping |
+| --- | --- | --- |
+| `Ask` | Creates a user task that prompts a human actor for input or approval. The first word after `Ask` becomes the assignee. | User Task (`human_input`)
+| `Do:` (system verbs) | When followed by verbs such as `create`, `update`, `delete`, `process`, `execute`, or `call`, produces an automated service task. | Service Task (`system_operation`)
+| `Do:` (manual verbs) | When followed by verbs such as `review`, `approve`, `check`, `verify`, or `inspect`, becomes a manual task assigned to a human. | Manual Task (`human_work`)
+| `Do:` (analytical verbs) | When followed by verbs such as `calculate`, `transform`, `analyze`, or `aggregate`, emits a script task. Subtypes like financial calculation or data transformation are inferred from the wording. | Script Task (`computation`)
+| `Do:` (rules verbs) | When followed by verbs such as `evaluate`, `determine`, or `classify`, maps to a business rule task. | Business Rule Task (`rule_evaluation`)
+| `Do:` (generic) | Any other `Do` statement is preserved as a generic task for downstream tooling. | Task (unspecified)
+| `Send` | Creates a message task. The compiler detects common channels (email, notification, SMS, Slack) to label the message type. | Message Task (`send`)
+| `Receive` | Marks a waiting state that resumes when a matching external event name is supplied to the simulator. | Intermediate Catch Event (`receive`)
+| `Wait` | Introduces an explicit timer wait. Simulation can either pause or auto-advance depending on configuration. | Timer Event (`wait`)
+| `Stop` | Signals the end of the workflow. | Terminate End Event
+| `Remember` | Any line that does not match the patterns above becomes a note stored in the compilation result. | `Remember to sync with finance`
+
+## Control Flow Keywords
+
+| Keyword | Purpose |
+| --- | --- |
+| `If` | Starts a conditional branch. The expression following `If` becomes the branch condition. |
+| `Otherwise` | Defines the alternate path when the preceding `If` condition is not met. Only one `Otherwise` is supported per `If` block. |
+| Nested `If` | `If` statements can appear inside an indented block to model nested conditions. |
+
+## Variable and Entity Detection
+
+The StoryFlow compiler extracts and normalizes variables automatically:
+
+- **Template variables**: Every `{variable}` placeholder is stored with a default description such as `input variable (variable)`.
+- **Boolean flags**: Conditions mentioning words like `approved`, `rejected`, or `available` automatically register those states as boolean variables.
+- **Actors**: Common role names (manager, employee, customer, admin, supervisor, owner, agent, lead) are converted to `{actor}` placeholders and recorded as workflow actors.
+- **Systems**: References to platforms such as “HR system”, “database”, “API”, or “service” are turned into snake_case placeholders like `{hr_system}` and marked as target systems.
+- **Action verbs**: Repeated verbs such as `create`, `send`, `process`, or `execute` become reusable `{action}` variables for downstream templating.
+
+## Messaging Metadata
+
+When you send communications, Kflow labels them for analytics:
+
+- Lines that include “email” are tagged as `email` messages.
+- Lines with “notification” become `notification` messages.
+- Lines mentioning “sms” or “Slack” are classified appropriately.
+- All other `Send` statements default to the generic `message` type.
+
+## Script Task Subtypes
+
+Analytical `Do:` statements are further categorized:
+
+- **Financial calculations** detect words like `interest`, `tax`, `discount`, or `payment`.
+- **Data transformations** look for verbs such as `transform`, `convert`, `normalize`, `parse`, or `merge`.
+- **Statistical analysis** recognizes `analyze`, `aggregate`, `count`, `median`, or `forecast`.
+- **Data validation** catches `validate`, `verify`, `check`, `reconcile`, or `audit`.
+- **Security operations** respond to `encrypt`, `decrypt`, `hash`, `authenticate`, or `authorize`.
+- **Text processing** picks up `generate`, `concatenate`, `substring`, or `regex`.
+- Any other analytical wording is labeled as `general_computation`.
+
+## Simulation Semantics
+
+The simulator walks the compiled IR graph with deterministic rules:
+
+- `Ask`, `Do`, `Send`, and `Receive` states push entries to the simulation log and enqueue the next state.
+- `Wait` either pauses execution (default) or advances automatically when `autoAdvanceWaits` is enabled.
+- `Choice` nodes select a branch based on provided hints or fall back to the first branch.
+- `Parallel` nodes enqueue every branch plus a join target.
+- `Stop` ends the run and marks the simulation status as `stopped`.
+
+Use this dictionary alongside the user manual to keep terminology consistent across authoring, compilation, and simulation.

--- a/docs/kflow-language-vision.md
+++ b/docs/kflow-language-vision.md
@@ -1,0 +1,67 @@
+# Kflow Language Enhancement Vision
+
+This document outlines where the language stands today, identifies missing capabilities (including case-based routing), and proposes a roadmap for iterative growth.
+
+## 1. Current Capabilities Snapshot
+
+The StoryFlow compiler recognizes a concise set of constructs:
+
+- Flow declaration plus linear steps.
+- Action keywords (`Ask`, `Do:`, `Send`, `Wait`, `Receive`, `Stop`) mapped to typed tasks.
+- Conditional branching limited to `If` / `Otherwise` structures.
+- Automatic extraction of template variables, actors, systems, and action verbs.
+- Intermediate representation (IR) states comprising task, user task, send, receive, choice, parallel, wait, and stop nodes.
+- Deterministic simulation that walks the IR graph, supports choice hints, parallel fan-out, waits, receives, and termination.
+
+These features deliver usable approval, fulfillment, and support workflows, but more advanced orchestration patterns remain unimplemented.
+
+## 2. Missing Language Building Blocks
+
+The following high-impact features are absent today. The count highlights the breadth of the gap.
+
+1. **Case-based routing (Switch/Case gateway)** – There is no syntax for enumerating named cases; branching is restricted to binary `If` and optional `Otherwise` statements, making multi-outcome routing verbose.
+2. **Loop constructs** – StoryFlow lacks `While`, `For`, or repeating task syntax, and the IR has no loop state, preventing iterative processes such as retries, reminders, or batch processing.
+3. **Event-based gateways** – Beyond a simple `Receive` wait, the language has no gateway that chooses a path based on which event arrives first, limiting responsiveness to competing signals.
+4. **Sub-process and call activity support** – The IR does not include sub-process nodes, so authors cannot encapsulate reusable flows or call child workflows.
+5. **Boundary error/timeout handling** – Although individual waits can time out, there is no structured syntax for attaching error or timeout handlers to tasks.
+6. **Multi-instance (for-each) behavior** – Tasks cannot run concurrently for a collection of items, restricting scenarios like notifying each regional manager or processing every invoice in a batch.
+
+> **Total missing core features identified: 6.**
+
+These gaps explain why case-based routing felt absent: it is part of a broader set of orchestration primitives that are yet to be modeled.
+
+## 3. Enhancement Roadmap
+
+The roadmap prioritizes foundational control-flow features before layering advanced tooling.
+
+### Phase 1 – Branching & Iteration
+
+- Introduce `Case` syntax that compiles to a multi-branch `choice` IR node with named paths.
+- Add `Loop`/`While` syntax and extend the IR with loop states or back-edges so the simulator can track iterations.
+- Provide indentation-aware validation to prevent malformed branches when these new keywords appear.
+
+### Phase 2 – Event Awareness
+
+- Extend the IR with `eventGateway` nodes that accept multiple `Receive` definitions and race them.
+- Support explicit timeout handlers, e.g., `On timeout` blocks under waits or user tasks.
+- Surface event metadata in the simulator (`waitingFor` should return every pending event option).
+
+### Phase 3 – Modularity & Reuse
+
+- Model sub-process tasks (`Call Flow`, `Inline Flow`) that reference other Kflow files.
+- Allow parameter passing into sub-processes and collect return variables on completion.
+- Add multi-instance markers, such as `For each {item}` sections that spawn parallel branches.
+
+### Phase 4 – Error & Compensation Management
+
+- Introduce `On error` and `On cancel` handlers for tasks and sub-processes.
+- Extend the IR and BPMN exporter to emit boundary events and compensation flows.
+- Update simulation to propagate failure states and trigger compensating actions.
+
+## 4. Documentation & Tooling Alignment
+
+- Update the dictionary and manual whenever a new keyword ships to keep authors informed.
+- Expand automated tests to cover branching permutations, loops, and event races.
+- Provide editor diagnostics that flag unsupported constructs until their runtime support is merged.
+
+By addressing the six missing building blocks above, Kflow can evolve from linear approval flows into a comprehensive orchestration language capable of modeling complex, event-driven business processes.

--- a/docs/kflow-user-manual.md
+++ b/docs/kflow-user-manual.md
@@ -1,0 +1,150 @@
+# Kflow User Manual
+
+This guide walks you through authoring, validating, and simulating workflows with the Kflow language toolkit.
+
+## 1. Prerequisites
+
+- **Runtime**: Node.js 18 or later.
+- **Package manager**: `pnpm` (recommended) or `npm`.
+- **Workspace setup**:
+  ```bash
+  pnpm install
+  pnpm -w -r build
+  ```
+  The build command compiles every package, including `@kflow/language` and the visual studio.
+
+## 2. Authoring a Flow
+
+1. **Start with a declaration**
+   ```kflow
+   Flow: Expense Reimbursement
+   ```
+2. **Describe human steps with `Ask`**
+   ```kflow
+   Ask employee to submit {receipt}
+   ```
+   The compiler treats the first word after `Ask` as the assignee and marks the task as human input.
+3. **Automate work with `Do:`**
+   - System operations: `Do: process reimbursement in finance system`
+   - Manual reviews: `Do: review receipt for policy compliance`
+   - Calculations: `Do: calculate reimbursement total`
+   Specialized verbs choose the appropriate BPMN task type automatically.
+4. **Communicate with `Send`**
+   ```kflow
+   Send notification to finance: "Reimbursement ready"
+   ```
+   Common channels such as email, SMS, and Slack are auto-detected.
+5. **Wait for external activity**
+   - `Wait 24 hours for manager approval`
+   - `Receive payment_confirmation`
+6. **Terminate with `Stop`** when the flow finishes.
+
+### Indentation Rules
+
+Use two spaces to nest steps under a condition:
+
+```kflow
+If {amount} > 1000
+  Ask manager to approve
+  If approved
+    Do: process expedited reimbursement
+Otherwise
+  Do: process automatically
+```
+
+Nested `If` blocks create multi-level branching structures. Every `If` can have a single `Otherwise` block.
+
+## 3. Working with Variables
+
+- Wrap parameters in `{curly_braces}` to mark them as template variables.
+- Actors like “manager” or “customer” and system names such as “HR system” are detected automatically and converted into template variables.
+- Conditional phrases like “If approved” register boolean flags so downstream tooling can track decision outcomes.
+
+These behaviors come from the StoryFlow compiler’s variable extraction pass.
+
+## 4. Converting Stories to SimpleScript
+
+Use the `storyToSimple` helper to translate StoryFlow prose into the SimpleScript JSON structure:
+
+```ts
+import { storyToSimple } from '@kflow/language';
+
+const simple = storyToSimple(`
+Flow: Expense Reimbursement
+Ask employee to submit {receipt}
+Do: validate receipt details
+If {amount} > 1000
+  Ask manager to approve
+Otherwise
+  Do: process automatically
+Stop
+`);
+
+console.log(simple);
+```
+
+`storyToSimple` splits the story into steps, converts recognized actions into typed tasks, and returns a formatted JSON string that includes template variables, task metadata, and branch structure.
+
+## 5. Simulating a Flow
+
+Import the `simulate` function to execute the compiled intermediate representation (IR):
+
+```ts
+import { simulate, IR } from '@kflow/language';
+
+const ir: IR = {
+  name: 'Expense Reimbursement',
+  start: 'start',
+  states: [
+    { id: 'start', kind: 'userTask', prompt: 'employee submit {receipt}', next: 'validate' },
+    { id: 'validate', kind: 'task', action: 'validate receipt details', next: 'decision' },
+    {
+      id: 'decision',
+      kind: 'choice',
+      branches: [
+        { cond: '{amount} > 1000', next: 'managerApproval' }
+      ],
+      otherwise: 'autoProcess'
+    },
+    { id: 'managerApproval', kind: 'userTask', prompt: 'manager approve', next: 'stop' },
+    { id: 'autoProcess', kind: 'task', action: 'process automatically', next: 'stop' },
+    { id: 'stop', kind: 'stop' }
+  ]
+};
+
+const result = simulate(ir, {
+  choices: { decision: 'autoProcess' },
+  autoAdvanceWaits: true
+});
+
+console.log(result.status); // 'completed'
+console.log(result.log);
+```
+
+Simulation returns:
+
+- `visited`: ordered list of state IDs.
+- `log`: typed entries describing tasks, waits, messages, and decisions.
+- `messages`: outbound communications emitted via `Send` states.
+- `status`: `completed`, `waiting`, or `stopped` when a `Stop` state is reached.
+- `waitingFor`: details about the state that paused execution (receive or wait).
+
+## 6. Studio Integration
+
+Run the studio for a visual editing experience:
+
+```bash
+pnpm --filter studio dev
+```
+
+Open `http://localhost:5173` in your browser to edit StoryFlow text side-by-side with the generated BPMN graph.
+
+## 7. Best Practices
+
+- Keep sentences action-oriented and present tense.
+- Prefer explicit system names (e.g., “finance system”) so the compiler can template them.
+- Use `Send` for every external communication to keep audit trails intact.
+- End every branch with either `Stop` or a step that rejoins the main flow.
+- Avoid mixing unrelated concerns inside a single flow; favor modular flows that can later become sub-processes.
+
+With this manual and the accompanying dictionary, teams can author consistent workflows while the compiler handles structure, metadata, and simulation.


### PR DESCRIPTION
## Summary
- add a dictionary that catalogues StoryFlow terminology, action keywords, and simulator semantics
- document authoring guidance, compilation helpers, and simulation workflows in a new user manual
- outline a language enhancement vision that counts six missing orchestration features, including case-based routing

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68db0393ba648323907e0c401e41ea79