### PR TITLE
fix: Add yaml dependency to studio package

### DIFF
--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -15,7 +15,8 @@
     "openai": "^4.104.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "reactflow": "^11.11.4"
+    "reactflow": "^11.11.4",
+    "yaml": "^2.3.4"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",


### PR DESCRIPTION
## Problem
Azure Static Web Apps deployment was failing on main branch with:
```
[vite]: Rollup failed to resolve import "yaml" from clarifications.ts
```

## Solution
Added `yaml` package to studio dependencies.

## Testing
- ✅ Local build passes: `pnpm build` in packages/studio
- ✅ All 376 modules transformed successfully
- ✅ Build output generated in dist/

## Impact
- Fixes Azure deployment for main branch
- Required by `clarifications.ts` for YAML parsing

## Urgency
🔴 **CRITICAL** - Blocks all Azure deployments from main branch